### PR TITLE
Restore original speed on mouse up

### DIFF
--- a/src/seek.js
+++ b/src/seek.js
@@ -2,6 +2,8 @@ const { core, overlay, console, event, input, menu } = iina;
 
 const TIMEOUT = 150;
 
+const SEEK_SPEED = 2;
+
 const IDLE = 0;
 const WAITING = 1;
 const SEEKING = 2;
@@ -17,45 +19,68 @@ export class SeekModule {
     this.addInputListeners();
   }
 
+  #initSeek(x,y) {
+    // only start seeking if the player is not paused
+    if (core.status.paused) {
+      return;
+    }
+
+    this.status = WAITING;
+
+    // show the overlay after a timeout.
+    setTimeout(() => {
+      // if the window is acturally dragged, cancel the seek
+      if (this.status != WAITING) {
+        return;
+      }
+
+      this.status = SEEKING;
+
+      overlay.show();
+      overlay.postMessage("mousePos", { x, y });
+
+      this.#startSeek();
+    }, TIMEOUT);
+  }
+
+  #startSeek() {
+    console.log("Start Seek");
+
+    this.originalSpeed = core.status.speed;
+
+    core.setSpeed(SEEK_SPEED);
+  }
+
   #cancelSeek() {
+    console.log("Cancel Seek");
+
     if (this.status === IDLE) {
       return;
     }
     if (this.status === SEEKING) {
-      core.setSpeed(1);
+      core.setSpeed(this.originalSpeed);
     }
-    console.log("Cancel Seek");
     this.status = IDLE;
     overlay.hide();
   }
 
   addInputListeners() {
     input.onMouseDown(input.MOUSE, (e) => {
-      const { x, y } = e;
       console.log("Mouse Down");
-      // only start seeking if the player is not paused
-      if (core.status.paused) {
-        return;
-      }
-      this.status = WAITING;
-      // show the overlay after a timeout.
-      // if the window is acturally dragged, cancel the seek
-      setTimeout(() => {
-        if (this.status != WAITING) {
-          return;
-        }
-        this.status = SEEKING;
-        overlay.show();
-        overlay.postMessage("mousePos", { x, y });
-        core.setSpeed(2);
-      }, TIMEOUT);
+
+      const { x, y } = e;
+      this.#initSeek(x, y);
     });
 
     input.onMouseUp(input.MOUSE, () => {
+      console.log("Mouse Up");
+
       this.#cancelSeek();
     });
 
     input.onMouseDrag(input.MOUSE, () => {
+      console.log("Mouse Drag");
+
       this.#cancelSeek();
     });
   }


### PR DESCRIPTION
Before clicking and holding the mouse button the play speed may differ from `1`, so we save the current speed in `this.originalSpeed` and restore it once seeking is over. 

Additionally, the PR includes a minor refactor that will facilitate the addition of more triggers, such as holding the spacebar, in the future.