### PR TITLE
Fix `npm run build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "serve-overlay": "parcel serve ui/overlay/index.html --dist-dir dist/ui/overlay",
-    "build": "rm -rf dist && parcel build .",
+    "build": "rm -rf .parcel-cache && rm -rf dist && parcel build .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
I had issues rebuilding the plugin until I added `rm -rf .parcel-cache` to the `build` script. The build was passing, however `dist/index.js` contents were not reflecting `src` changes.